### PR TITLE
Update CellChat_class.R

### DIFF
--- a/R/CellChat_class.R
+++ b/R/CellChat_class.R
@@ -143,7 +143,7 @@ createCellChat <- function(object, meta = NULL, group.by = NULL,
                            assay = NULL, do.sparse = T) {
   datatype <- match.arg(datatype)
   # data matrix as input
-  if (inherits(x = object, what = c("matrix", "Matrix", "dgCMatrix"))) {
+  if (inherits(x = object, what = c("matrix", "Matrix", "Matrix"))) {
     print("Create a CellChat object from a data matrix")
     data <- object
     if (is.null(group.by)) {
@@ -208,7 +208,7 @@ createCellChat <- function(object, meta = NULL, group.by = NULL,
   }
 
   if (!inherits(x = data, what = c("dgCMatrix")) & do.sparse) {
-    data <- as(data, "dgCMatrix")
+    data <- as(data, "CsparseMatrix")
   }
 
   if (!is.null(meta)) {


### PR DESCRIPTION
I got an error when trying to feed the createCellChat function a SingleCellExperiment containing dgRMatrix format in logcounts. The error occurs in trying to coerce a dgRMatrix to dgCMatrix, but it works to coerce to "CsparseMatrix", which ultimately results in a dgCMatrix. 

Supposedly this issue has been resolved in zellkonverter a couple years ago, (https://github.com/theislab/zellkonverter/issues/55), but I just ran into this today with data imported with zellkonverter which was a dgRMatrix, and my packages are up to date. I then found a couple other issues with discussion of this particular conversion problem, so I would suggest making this small update so that it will seamlessly work with dgRMatrix input too! 
e.g., https://github.com/theislab/zellkonverter/issues/34 suggests this solution as well

According to this Seurat issue, as(., 'dgCMatrix') also got deprecated for other Matrix input types as well
https://github.com/satijalab/seurat/issues/6438