### PR TITLE
Add a 'seed' parameter to the netEmbedding function

### DIFF
--- a/R/analysis.R
+++ b/R/analysis.R
@@ -643,6 +643,7 @@ computeNetSimilarityPairwise <- function(object, slot.name = "netP", type = c("f
 #' @param min_dist This controls how tightly the embedding is allowed compress points together.
 #' Larger values ensure embedded points are moreevenly distributed, while smaller values allow the
 #' algorithm to optimise more accurately with regard to local structure. Sensible values are in the range 0.001 to 0.5.
+#' @param seed An integer value indicating the random seed passed to \code{\link[base]{set.seed}}, use `NULL` to re-initializes seed. Defaults to 42.
 #' @param ... Parameters passing to umap
 #' @importFrom methods slot
 #' @return
@@ -650,7 +651,7 @@ computeNetSimilarityPairwise <- function(object, slot.name = "netP", type = c("f
 #'
 #' @examples
 netEmbedding <- function(object, slot.name = "netP", type = c("functional","structural"), comparison = NULL, pathway.remove = NULL,
-                         umap.method = c("umap-learn", "uwot"), n_neighbors = NULL,min_dist = 0.3,...) {
+                         umap.method = c("umap-learn", "uwot"), n_neighbors = NULL, min_dist = 0.3, seed = 42,...) {
   umap.method <- match.arg(umap.method)
   if (object@options$mode == "single") {
     comparison <- "single"
@@ -674,11 +675,21 @@ netEmbedding <- function(object, slot.name = "netP", type = c("functional","stru
     n_neighbors <- ceiling(sqrt(dim(Similarity)[1])) + 1
   }
   options(warn = -1)
+
+  if (is.numeric(seed)) {
+    seed <- as.integer(seed)
+  }
+
   # dimension reduction
   if (umap.method == "umap-learn") {
-    Y <- runUMAP(Similarity, min_dist = min_dist, n_neighbors = n_neighbors,...)
+    Y <- runUMAP(Similarity, min_dist = min_dist, n_neighbors = n_neighbors, seed.use = seed,...)
   } else if (umap.method == "uwot") {
-    Y <- uwot::umap(Similarity, min_dist = min_dist, n_neighbors = n_neighbors,...)
+    if(packageVersion("uwot")<"0.1.15") {
+      set.seed(seed)
+      Y <- uwot::umap(Similarity, min_dist = min_dist, n_neighbors = n_neighbors,...)
+    } else {
+      Y <- uwot::umap(Similarity, min_dist = min_dist, n_neighbors = n_neighbors, seed = seed...)
+    }
     colnames(Y) <- paste0('UMAP', 1:ncol(Y))
     rownames(Y) <- colnames(Similarity)
   }

--- a/man/netEmbedding.Rd
+++ b/man/netEmbedding.Rd
@@ -13,6 +13,7 @@ netEmbedding(
   umap.method = c("umap-learn", "uwot"),
   n_neighbors = NULL,
   min_dist = 0.3,
+  seed = 42,
   ...
 )
 }
@@ -36,6 +37,8 @@ Can be umap-learn: Run the python umap-learn package; uwot: Runs umap via the uw
 \item{min_dist}{This controls how tightly the embedding is allowed compress points together.
 Larger values ensure embedded points are moreevenly distributed, while smaller values allow the
 algorithm to optimise more accurately with regard to local structure. Sensible values are in the range 0.001 to 0.5.}
+
+\item{seed}{An integer value indicating the random seed passed to \code{\link{set.seed}}, use `NULL` to re-initializes seed. Defaults to 42.}
 
 \item{...}{Parameters passing to umap}
 }


### PR DESCRIPTION
A PR with similar changes has been submitted before to https://github.com/sqjin/CellChat/pull/679 to help with the reproducibility of UMAP plots when running the `netEmbedding` function.

---

The PR adds a `seed` paramter to the `netEmbedding` function to allow generating reproducible UMAPs, as requested in https://github.com/sqjin/CellChat/issues/155, https://github.com/sqjin/CellChat/issues/196 and https://github.com/sqjin/CellChat/issues/435. This works on both `umap-learn` and `uwot` methods. The default setting is `seed = 42`. One can use `seed = NULL` to reset and produce a different set of embeddings.