### PR TITLE
Use unique heatmap name, and other feature updates

### DIFF
--- a/man/netVisual_heatmap.Rd
+++ b/man/netVisual_heatmap.Rd
@@ -13,6 +13,7 @@ netVisual_heatmap(
   color.use = NULL,
   color.heatmap = NULL,
   title.name = NULL,
+  legend.title = NULL,
   width = NULL,
   height = NULL,
   font.size = 8,
@@ -44,9 +45,11 @@ By default, color.heatmap = c('#2166ac','#b2182b') when taking a merged CellChat
 
 \item{title.name}{the name of the title}
 
-\item{width}{width of heatmap}
+\item{legend.title}{the title of the heatmap legend}
 
-\item{height}{height of heatmap}
+\item{width}{width of the heatmap bidy, should be a fixed `unit` object}
+
+\item{height}{height of the heatmap body, should be a fixed `unit` object}
 
 \item{font.size}{fontsize in heatmap}
 


### PR DESCRIPTION
A PR with similar changes has been submitted before to https://github.com/sqjin/CellChat/pull/696 to fix an issue with combining heatmaps that are produced by `netVisual_heatmap`.

---

This PR (1) resolve the issue with duplicated `Heatmap` object name when joining 2 or more Heatmap objects created by the `netVisual_heatmap` function, by create a unique `ht.name` name and passed to the `Heatmap` function.

When creating a heatmap list in the later version of `ComplexHeatmap`, each `Heatmap` object should have a unique name, if not, a warning message such as `Heatmap/annotation names are duplicated` is produced (as noted in https://github.com/sqjin/CellChat/issues/170).

This PR (2) adds the ability for users to assign legend title to each heatmap using `legend.title`. This is useful when creating plots showing heatmap side-by-side to compare number/strength of interactions from multiple datasets, with legend named specifically for each dataset.

This PR (3) re-introduce the paramaters for users to change the `width` and `height` of the heatmap body.

Minor changes are to standardise the font size of the legend title and label from `fontsize = 8` to use `font.size` which default to `8`.