### PR TITLE
Avoid situations where sources.use or targets.use is NULL.

### DIFF
--- a/R/visualization.R
+++ b/R/visualization.R
@@ -2210,7 +2210,9 @@ netVisual_bubble <- function(object, sources.use = NULL, targets.use = NULL, sig
                                   pairLR.use = pairLR.use,
                                   thresh = thresh)
     df.net$source.target <- paste(df.net$source, df.net$target, sep = " -> ")
-    source.target <- paste(rep(sources.use, each = length(targets.use)), targets.use, sep = " -> ")
+    if (!(is.null(sources.use) || is.null(targets.use))){
+      source.target <- paste(rep(sources.use, each = length(targets.use)), targets.use, sep = " -> ")
+    }
     source.target.isolate <- setdiff(source.target, unique(df.net$source.target))
     if (length(source.target.isolate) > 0) {
       df.net.isolate <- as.data.frame(matrix(NA, nrow = length(source.target.isolate), ncol = ncol(df.net)))


### PR DESCRIPTION
if sources.use or targets.use is NULL, the source.target will be NA
![image](https://github.com/user-attachments/assets/d4527514-e8a5-4f5c-852f-82a6f2bde00b)
