### PR TITLE
Update analysis.R

### DIFF
--- a/R/analysis.R
+++ b/R/analysis.R
@@ -2852,14 +2852,14 @@ netAnalysis_signalingRole_heatmap <- function(object, signaling = NULL, pattern 
   }
   mat.ori <- mat
   mat <- sweep(mat, 1L, apply(mat, 1, max), '/', check.margin = FALSE)
-  mat[mat == 0] <- NA
+  #mat[mat == 0] <- NA
 
 
   if (is.null(color.use)) {
     color.use <- scPalette(length(colnames(mat)))
   }
-  color.heatmap.use = grDevices::colorRampPalette((RColorBrewer::brewer.pal(n = 9, name = color.heatmap)))(100)
-
+  #color.heatmap.use = grDevices::colorRampPalette((RColorBrewer::brewer.pal(n = 9, name = color.heatmap)))(100)
+  color.heatmap.use <- c("white", grDevices::colorRampPalette(RColorBrewer::brewer.pal(n = 9, name = color.heatmap))(100))
   df<- data.frame(group = colnames(mat)); rownames(df) <- colnames(mat)
   names(color.use) <- colnames(mat)
   col_annotation <- HeatmapAnnotation(df = df, col = list(group = color.use),which = "column",


### PR DESCRIPTION
To avoid introducing NA values, which cause errors when clustering rows in the pheatmap function, I modified the color palette to start with white for zero values. This adjustment leaves the data unchanged but enables consistent visualization without triggering the error.

old code produces following error:
![image](https://github.com/user-attachments/assets/2032dc73-9abf-4a37-afe8-a9091f0309a3)
