### PR TITLE
Fix: Enable parallelization in computeCommunProb bootstrap loop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: CellChat
 Type: Package
 Title: Inference and analysis of cell-cell communication from single-cell and spatially resolved transcriptomics data 
-Version: 2.2.0
+Version: 2.2.0.9001
 Author: Suoqin Jin
 Maintainer: Suoqin Jin <sqjin@whu.edu.cn>
 Description: an open source R tool that infers, visualizes and analyzes the cell-cell communication networks from scRNA-seq and spatially resolved transcriptomics data.

--- a/R/modeling.R
+++ b/R/modeling.R
@@ -258,7 +258,7 @@ computeCommunProb <- function(object, type = c("triMean", "truncatedMean","thres
       Pnull <- as.vector(Pnull)
 
       #Pboot <- foreach(nE = 1:nboot) %dopar% {
-      Pboot <- sapply(
+      Pboot <- my.sapply(
         X = 1:nboot,
         FUN = function(nE) {
           data.use.avgB <- data.use.avg.boot[[nE]]


### PR DESCRIPTION
## Problem
`computeCommunProb` runs single-threaded even when `future::plan()` is configured with multiple workers. This was reported in #411 but closed without a fix.

## Root Cause
Line 261 in `R/modeling.R` uses `sapply` instead of the parallel-aware `my.sapply` for the bootstrap p-value computation. This inner loop runs `nboot` (default 100) iterations for each of the ~2,000 L-R pairs — all sequentially.

## Fix
One-line change: `sapply` → `my.sapply` on line 261.

## Results
Tested on 40,000 cells with 64 CPUs:
| Before | After |
|--------|-------|
| ~46 hours | ~5.2 hours |

Fixes #411