### PR TITLE
Fix the problem of the self-node visualization problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+src/CellChat_Rcpp.o
+src/CellChat.so
+src/RcppExports.o

--- a/R/visualization.R
+++ b/R/visualization.R
@@ -1333,7 +1333,7 @@ netVisual_circle <-function(net, color.use = NULL,title.name = NULL, sources.use
   }
   vertex.weight <- vertex.weight/vertex.weight.max*vertex.size.max+5
 
-  loop.angle<-ifelse(coords_scale[igraph::V(g),1]>0,-atan(coords_scale[igraph::V(g),2]/coords_scale[igraph::V(g),1]),pi-atan(coords_scale[igraph::V(g),2]/coords_scale[igraph::V(g),1]))
+  loop.angle<-ifelse(coords_scale[igraph::V(g),1]>0,-atan(coords_scale[igraph::V(g),2]/coords_scale[igraph::V(g),1]),pi-atan(coords_scale[igraph::V(g),2]/coords_scale[igraph::V(g),1])) * -1
   igraph::V(g)$size<-vertex.weight
   igraph::V(g)$color<-color.use[igraph::V(g)]
   igraph::V(g)$frame.color <- color.use[igraph::V(g)]
@@ -1736,7 +1736,7 @@ netVisual_diffInteraction <- function(object, comparison = c(1,2), measure = c("
   }
   vertex.weight <- vertex.weight/vertex.weight.max*vertex.size.max+5
 
-  loop.angle<-ifelse(coords_scale[igraph::V(g),1]>0,-atan(coords_scale[igraph::V(g),2]/coords_scale[igraph::V(g),1]),pi-atan(coords_scale[igraph::V(g),2]/coords_scale[igraph::V(g),1]))
+  loop.angle<-ifelse(coords_scale[igraph::V(g),1]>0,-atan(coords_scale[igraph::V(g),2]/coords_scale[igraph::V(g),1]),pi-atan(coords_scale[igraph::V(g),2]/coords_scale[igraph::V(g),1])) * -1
   igraph::V(g)$size<-vertex.weight
   igraph::V(g)$color<-color.use[igraph::V(g)]
   igraph::V(g)$frame.color <- color.use[igraph::V(g)]


### PR DESCRIPTION
the loops in the same node in circle plot have wrong direction. 

<img width="1500" height="1800" alt="image" src="https://github.com/user-attachments/assets/80f10630-6f86-46b0-b383-af87503d7095" />

adding "* -1" to the loop.angle assignment fix the problem.

Line 1336 and 1739:
loop.angle<-ifelse(coords_scale[igraph::V(g),1]>0,-atan(coords_scale[igraph::V(g),2]/coords_scale[igraph::V(g),1]),pi-atan(coords_scale[igraph::V(g),2]/coords_scale[igraph::V(g),1])) * -1

<img width="1500" height="1800" alt="HGPS circle_weight" src="https://github.com/user-attachments/assets/719addca-61ad-4622-8acd-a12f3e95af57" />
